### PR TITLE
Fix variable reference in deploygbm function

### DIFF
--- a/Jupyter Notebooks/4-modeling-scoring-rre.ipynb
+++ b/Jupyter Notebooks/4-modeling-scoring-rre.ipynb
@@ -830,7 +830,7 @@
     "deploygbm<-function (newdata)\n",
     "{  \n",
     "  require(gbm)\n",
-    "  predict(gbm_publish, newdata_df, n.trees=10, type=\"response\")\n",
+    "  predict(gbm_publish, newdata, n.trees=10, type=\"response\")\n",
     " \n",
     "}\n",
     "\n"


### PR DESCRIPTION
Functin `deploygbm` is currently referencing `newdata_df` which holds full dataset. It should use its own parameter `neadata` instead.